### PR TITLE
Don't open file twice when specified by absolute path.

### DIFF
--- a/file.c
+++ b/file.c
@@ -5796,11 +5796,11 @@ rb_find_file_ext_safe(VALUE *filep, const char *const *ext, int safe_level)
 VALUE
 rb_find_file(VALUE path)
 {
-    return rb_find_file_safe(path, rb_safe_level());
+    return rb_find_file_safe(path, rb_safe_level(), 0);
 }
 
 VALUE
-rb_find_file_safe(VALUE path, int safe_level)
+rb_find_file_safe(VALUE path, int safe_level, int defer_load_check)
 {
     VALUE tmp, load_path;
     const char *f = StringValueCStr(path);
@@ -5820,7 +5820,9 @@ rb_find_file_safe(VALUE path, int safe_level)
 	if (safe_level >= 1 && !fpath_check(path)) {
 	    rb_raise(rb_eSecurityError, "loading from unsafe path %s", f);
 	}
-	if (!rb_file_load_ok(f)) return 0;
+	if (!defer_load_check && !rb_file_load_ok(f)) {
+	    return 0;
+	}
 	if (!expanded)
 	    path = copy_path_class(file_expand_path_1(path), path);
 	return path;

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -478,7 +478,7 @@ VALUE rb_file_s_absolute_path(int, const VALUE *);
 VALUE rb_file_absolute_path(VALUE, VALUE);
 VALUE rb_file_dirname(VALUE fname);
 int rb_find_file_ext_safe(VALUE*, const char* const*, int);
-VALUE rb_find_file_safe(VALUE, int);
+VALUE rb_find_file_safe(VALUE, int, int);
 int rb_find_file_ext(VALUE*, const char* const*);
 VALUE rb_find_file(VALUE);
 VALUE rb_file_directory_p(VALUE,VALUE);

--- a/load.c
+++ b/load.c
@@ -859,7 +859,7 @@ search_required(VALUE fname, volatile VALUE *path, int safe_level)
 		if (loading) *path = rb_filesystem_str_new_cstr(loading);
 		return 'r';
 	    }
-	    if ((tmp = rb_find_file_safe(fname, safe_level)) != 0) {
+	    if ((tmp = rb_find_file_safe(fname, safe_level, 1)) != 0) {
 		ext = strrchr(ftptr = RSTRING_PTR(tmp), '.');
 		if (!rb_feature_p(ftptr, ext, TRUE, TRUE, &loading) || loading)
 		    *path = tmp;
@@ -884,7 +884,7 @@ search_required(VALUE fname, volatile VALUE *path, int safe_level)
 #else
 	    rb_str_cat2(tmp, DLEXT);
 	    OBJ_FREEZE(tmp);
-	    if ((tmp = rb_find_file_safe(tmp, safe_level)) != 0) {
+	    if ((tmp = rb_find_file_safe(tmp, safe_level, 0)) != 0) {
 		ext = strrchr(ftptr = RSTRING_PTR(tmp), '.');
 		if (!rb_feature_p(ftptr, ext, FALSE, TRUE, &loading) || loading)
 		    *path = tmp;
@@ -897,7 +897,7 @@ search_required(VALUE fname, volatile VALUE *path, int safe_level)
 		if (loading) *path = rb_filesystem_str_new_cstr(loading);
 		return 's';
 	    }
-	    if ((tmp = rb_find_file_safe(fname, safe_level)) != 0) {
+	    if ((tmp = rb_find_file_safe(fname, safe_level, 0)) != 0) {
 		ext = strrchr(ftptr = RSTRING_PTR(tmp), '.');
 		if (!rb_feature_p(ftptr, ext, FALSE, TRUE, &loading) || loading)
 		    *path = tmp;


### PR DESCRIPTION
When invoking `require '/a.rb'` (i.e. via an absolute path), ruby
generates this sequence of syscalls:

    open    /a.rb
    fstat64 /a.rb
    close   /a.rb
    open    /a.rb
    fstat64 /a.rb
    fstat64 /a.rb
    read    /a.rb
    close   /a.rb

It is apparent that the only inherently necessary members of this
sequence are:

    open    /a.rb
    fstat64 /a.rb
    read    /a.rb
    close   /a.rb

(the fstat64 isn't *obviously* necessary, but it does serve a purpose
and probably shouldn't be removed).

The first open/fstat64/close is used to check whether the file is
loadable. This is important when scanning the `$LOAD_PATH`, since it is
used to determine when a file has been found. However, when we've
already unambiguously identified a file before invoking `require`, this
serves no inherent purpose, since we can move whatever work is happening
as a result of that `fstat64` into the second open/close sequence.

This change bypasses the first open/fstat64/close in the case of an
absolute path to `require`. It also removes one of the doubled-up
`fstat64` calls later in the sequence. As a result, the number of
syscalls to require a file changes:

* From 8 to 4 when specified by absolute path;
* From 8 to 7 otherwise.

In future work, it would be possible to re-use the file descriptor
opened while searching the `$LOAD_PATH` without the close/open sequence,
but this would cause some ugly layering issues.

[*(Various related notes, more elaboration)*](http://notes.burke.libbey.me/ruby-require-optimization/)